### PR TITLE
Support accessibilityFrame

### DIFF
--- a/Sources/UIView+TouchAreaInsets.m
+++ b/Sources/UIView+TouchAreaInsets.m
@@ -10,6 +10,8 @@
                                    class_getInstanceMethod(self, @selector(_touchAreaInsets_pointInside:withEvent:)));
     method_exchangeImplementations(class_getInstanceMethod(self, @selector(accessibilityFrame)),
                                    class_getInstanceMethod(self, @selector(_touchAreaInsets_accessibilityFrame)));
+    method_exchangeImplementations(class_getInstanceMethod(self, @selector(setAccessibilityFrame:)),
+                                   class_getInstanceMethod(self, @selector(_touchAreaInsets_setInternalAccessibilityFrame:)));
   });
 }
 
@@ -23,21 +25,34 @@
 }
 
 - (BOOL)_touchAreaInsets_pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-  CGRect bounds = [self expandFrame:self.bounds
-                         withInsets:self.touchAreaInsets];
+  CGRect bounds = [self _touchAreaInsets_expandFrame:self.bounds
+                                          withInsets:self.touchAreaInsets];
   return CGRectContainsPoint(bounds, point);
 }
 
 - (CGRect)_touchAreaInsets_accessibilityFrame {
-  return [self expandFrame:UIAccessibilityConvertFrameToScreenCoordinates(self.bounds, self)
-                withInsets:self.touchAreaInsets];
+  CGRect internalAccessibilityFrame = [self _touchAreaInsets_interalAccessibilityFrame];
+  if (!CGRectIsEmpty(internalAccessibilityFrame)) {
+    return internalAccessibilityFrame;
+  }
+  return [self _touchAreaInsets_expandFrame:UIAccessibilityConvertFrameToScreenCoordinates(self.bounds, self)
+                                 withInsets:self.touchAreaInsets];
 }
 
-- (CGRect)expandFrame:(CGRect)frame withInsets:(UIEdgeInsets)insets {
+- (CGRect)_touchAreaInsets_expandFrame:(CGRect)frame withInsets:(UIEdgeInsets)insets {
   return CGRectMake(frame.origin.x - insets.left,
                     frame.origin.y - insets.top,
                     frame.size.width + insets.left + insets.right,
                     frame.size.height + insets.top + insets.bottom);
+}
+
+- (CGRect)_touchAreaInsets_interalAccessibilityFrame {
+  return [objc_getAssociatedObject(self, @selector(_touchAreaInsets_interalAccessibilityFrame)) CGRectValue];
+}
+
+- (void)_touchAreaInsets_setInternalAccessibilityFrame:(CGRect)accessibilityFrame {
+  NSValue *value = [NSValue valueWithCGRect:accessibilityFrame];
+  objc_setAssociatedObject(self, @selector(_touchAreaInsets_interalAccessibilityFrame), value, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end

--- a/Sources/UIView+TouchAreaInsets.m
+++ b/Sources/UIView+TouchAreaInsets.m
@@ -8,6 +8,8 @@
   dispatch_once(&onceToken, ^{
     method_exchangeImplementations(class_getInstanceMethod(self, @selector(pointInside:withEvent:)),
                                    class_getInstanceMethod(self, @selector(_touchAreaInsets_pointInside:withEvent:)));
+    method_exchangeImplementations(class_getInstanceMethod(self, @selector(accessibilityFrame)),
+                                   class_getInstanceMethod(self, @selector(_touchAreaInsets_accessibilityFrame)));
   });
 }
 
@@ -21,13 +23,21 @@
 }
 
 - (BOOL)_touchAreaInsets_pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-  UIEdgeInsets touchAreaInsets = self.touchAreaInsets;
-  CGRect bounds = self.bounds;
-  bounds = CGRectMake(bounds.origin.x - touchAreaInsets.left,
-                      bounds.origin.y - touchAreaInsets.top,
-                      bounds.size.width + touchAreaInsets.left + touchAreaInsets.right,
-                      bounds.size.height + touchAreaInsets.top + touchAreaInsets.bottom);
+  CGRect bounds = [self expandFrame:self.bounds
+                         withInsets:self.touchAreaInsets];
   return CGRectContainsPoint(bounds, point);
+}
+
+- (CGRect)_touchAreaInsets_accessibilityFrame {
+  return [self expandFrame:UIAccessibilityConvertFrameToScreenCoordinates(self.bounds, self)
+                withInsets:self.touchAreaInsets];
+}
+
+- (CGRect)expandFrame:(CGRect)frame withInsets:(UIEdgeInsets)insets {
+  return CGRectMake(frame.origin.x - insets.left,
+                    frame.origin.y - insets.top,
+                    frame.size.width + insets.left + insets.right,
+                    frame.size.height + insets.top + insets.bottom);
 }
 
 @end

--- a/Tests/TouchAreaInsetsTests.swift
+++ b/Tests/TouchAreaInsetsTests.swift
@@ -38,5 +38,20 @@ class Tests: XCTestCase {
     XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 105, y: 50)), true)
     XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 50, y: 105)), true)
   }
+  
+  func testTouchArea_withAccessibilityFrame() {
+    let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+    view.accessibilityFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
+    view.touchAreaInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+    XCTAssertEqual(view.point(inside: CGPoint(x: 50, y: -5), with: nil), true)
+    XCTAssertEqual(view.point(inside: CGPoint(x: -5, y: 50), with: nil), true)
+    XCTAssertEqual(view.point(inside: CGPoint(x: 105, y: 50), with: nil), true)
+    XCTAssertEqual(view.point(inside: CGPoint(x: 50, y: 105), with: nil), true)
+    
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 50, y: -5)), false)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: -5, y: 50)), false)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 105, y: 50)), false)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 50, y: 105)), false)
+  }
 
 }

--- a/Tests/TouchAreaInsetsTests.swift
+++ b/Tests/TouchAreaInsetsTests.swift
@@ -18,6 +18,11 @@ class Tests: XCTestCase {
     XCTAssertEqual(view.point(inside: CGPoint(x: -5, y: 50), with: nil), false)
     XCTAssertEqual(view.point(inside: CGPoint(x: 105, y: 50), with: nil), false)
     XCTAssertEqual(view.point(inside: CGPoint(x: 50, y: 105), with: nil), false)
+    
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 50, y: -5)), false)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: -5, y: 50)), false)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 105, y: 50)), false)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 50, y: 105)), false)
   }
 
   func testTouchArea_withInsets() {
@@ -27,6 +32,11 @@ class Tests: XCTestCase {
     XCTAssertEqual(view.point(inside: CGPoint(x: -5, y: 50), with: nil), true)
     XCTAssertEqual(view.point(inside: CGPoint(x: 105, y: 50), with: nil), true)
     XCTAssertEqual(view.point(inside: CGPoint(x: 50, y: 105), with: nil), true)
+    
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 50, y: -5)), true)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: -5, y: 50)), true)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 105, y: 50)), true)
+    XCTAssertEqual(view.accessibilityFrame.contains(CGPoint(x: 50, y: 105)), true)
   }
 
 }


### PR DESCRIPTION
## Background (Current)
Using this library we can simply modify the touch area.
However, for voice over users, the focus area is calculated based on the frame that does not contain `touchAreaInsets`.

## Summary
This PR adds `touchAreaInsets` value to the `accessibilityFrame`.
Exceptionally, if a client sets `accessibilityFrame`, it simply returns the `accessibilityFrame` specified by the client.

## Example Usage
Same as previous usage